### PR TITLE
Fix "Arguments to path.join must be strings" in new versions of node

### DIFF
--- a/lib/runners/node.js
+++ b/lib/runners/node.js
@@ -107,7 +107,7 @@ var testRun = {
                 }.bind(this, null)
             });
             test.testContext.on("create", runner);
-            var fullPath = path.join.bind(path, rs.rootPath);
+            var fullPath = function(p) { return path.join(rs.rootPath, p); };
             rs.loadPath.paths().map(fullPath).forEach(descriptiveRequire);
         } catch (e) {
             e.code = EX_DATAERR;


### PR DESCRIPTION
I was getting an error "Arguments to path.join must be strings" (with no stack trace; this was the entire output) on running `buster test`.  This patch fixes the problem.
