### PR TITLE
autoRun config option should not be ignored.

### DIFF
--- a/lib/runners/browser.js
+++ b/lib/runners/browser.js
@@ -239,7 +239,7 @@ var testRun = {
                 path: "/buster/configure-test-run.js",
                 content: "buster.configureTestRun(" + JSON.stringify({
                     failOnNoAssertions: opt(this.options, "failOnNoAssertions", true),
-                    autoRun: opt(this.options, "autoRun", true),
+                    autoRun: opt(this.config.options, "autoRun", true),
                     captureConsole: opt(this.options, "captureConsole", true),
                     filters: opt(this.options, "filters", undefined)
                 }) + ");"


### PR DESCRIPTION
autoRun is set on the `this.config.options` object. There are no autoRun options to be found in `this.options`.
