### PR TITLE
Added "fail-on-no-assertion" option to cli args.

### DIFF
--- a/lib/test-cli.js
+++ b/lib/test-cli.js
@@ -162,6 +162,7 @@ function prepareOptions(prefs, args) {
         cacheResources: !args["--reset"].isSet,
         warnings: args["--warnings"].value,
         failOn: args["--fail-on"].value,
+				failOnNoAssertions: !!args["--fail-if-no-assertion"].isSet,
         captureConsole: !cli.pref(prefs, args["--release-console"], "test.releaseConsole"),
         staticResourcesPath: args["--static-paths"].isSet,
         logPassedMessages: !cli.pref(prefs, args["--quiet-log"], "test.quietLog"),


### PR DESCRIPTION
Currently fail-on-no-assertion is always true on browsers.