### PR TITLE
allowing autoRun to be overridden properly

### DIFF
--- a/lib/runners/browser.js
+++ b/lib/runners/browser.js
@@ -248,9 +248,10 @@ var testRun = {
     },
 
     getClientRunConfig: function () {
+        this.options = _.extend({}, this.options, this.config.options);
         return {
             failOnNoAssertions: opt(this.options, "failOnNoAssertions", true),
-            autoRun: opt(this.options, "autoRun", true),
+            autoRun: typeof(this.config.autoRun) !== "undefined" ? this.config.autoRun : opt(this.options, "autoRun", true),
             captureConsole: opt(this.options, "captureConsole", true),
             allowFocusMode: opt(this.options, "allowFocusMode", true),
             filters: opt(this.options, "filters", undefined)
@@ -271,7 +272,6 @@ var testRun = {
 
             try {
                 if (this.aborted) { return this.endSession(sessionInit); }
-                this.options = _.extend({}, this.options, this.config.options);
                 this.runTests(sessionInit, done);
             } catch (e) {
                 done(e);

--- a/test/runners/browser-test.js
+++ b/test/runners/browser-test.js
@@ -410,15 +410,53 @@ buster.testCase("Browser runner", {
                 failOnNoAssertions: false
             }),
 
-            "defaults auto-run to true": testRemoteRunnerOption({}, {
-                autoRun: true
-            }),
+            "defaults auto-run to true": testRemoteRunnerOption({}, { autoRun: true }),
 
             "configures to not auto-run": testRemoteRunnerOption({
                 autoRun: false
             }, {
                 autoRun: false
             }),
+
+            "auto-run": {
+                "defaults to true": testRemoteRunnerOption({}, { autoRun: true }),
+                "overrides to not auto-run via options": testRemoteRunnerOption({ autoRun: false }, { autoRun: false }),
+                "overrides to not auto-run via config": function () {
+                    // this tests that we can have autoRun: false in buster.js config file
+                    var run = testRun.create(fakeConfig(this), {}, this.logger);
+                    run.config = {
+                        autoRun: false
+                    };
+
+                    var actual = run.getClientRunConfig();
+                    refute(actual.autoRun);
+                },
+                "overrides to not auto-run via config.options": function () {
+                    // this tests that buster-amd can set conf.options.autoRun = false during its configure() phase
+                    // this also checks that run.config.options is merged into run.options
+                    var run = testRun.create(fakeConfig(this), { autoRun: true }, this.logger);
+                    run.config = {
+                        options: {
+                            autoRun: false
+                        }
+                    };
+
+                    var actual = run.getClientRunConfig();
+                    refute(actual.autoRun); // config.options.autoRun - not options.autoRun
+                },
+                "config.autoRun more important than config.options.autoRun": function () {
+                    var run = testRun.create(fakeConfig(this), {}, this.logger);
+                    run.config = {
+                        autoRun: false,
+                        options: {
+                            autoRun: true
+                        }
+                    };
+
+                    var actual = run.getClientRunConfig();
+                    refute(actual.autoRun); // config.autoRun - not config.options.autoRun
+                }
+            },
 
             "defaults filters to undefined": function () {
                 // "pretty" implementation needs https://github.com/busterjs/samsam/pull/9


### PR DESCRIPTION
After some discussion on IRC, it seems that some configurability was lost - restoring just that.

Basically, at some point, the merging of `this.options` and `this.config.options` started happening at the wrong place - so I moved it to happen earlier - during `getClientRunConfig()` which gets called during `sessionStart()` - it should be safe, since that happens after `this.config.resolve()`. This allows `buster-amd` to function properly, as it sets `conf.options.autoRun`: https://github.com/busterjs/buster-amd/blob/master/lib/buster-amd.js#L32

The docs for `buster.js` file say: "Add { autoRun: false } to your config file and call buster.run() to start the test run. That gives you full control over when the test run starts." - this property gets exposed directly as `this.config.autoRun`, so if it is there - it's being used.

The final result is this:
- If `this.config.autoRun` (from `buster.js`) is set - use that
- Otherwise, if `this.config.options.autoRun` is set, it overrides whatever is set in `this.options.autoRun` and is used (`buster-amd` sets that)
- Otherwise use whatever is set in `this.options.autoRun` (Is this even possible? Is there anything that can set it there?)
- Otherwise use default value - `autoRun` is `true`
