### PR TITLE
Update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 node_modules
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.gitignore
-.npmignore
-todo.org
-node_modules
-public/images/.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: node_js
+sudo: false
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+before_install:
+  - npm i -g npm

--- a/lib/runners/browser.js
+++ b/lib/runners/browser.js
@@ -265,7 +265,7 @@ var testRun = {
             this.onInterrupt(function () { sessionInit.endSession(); });
 
             sessionInit.onSessionAbort(function (e) {
-                done({ message: e.error });
+                this.abort(new Error(e.error || "Browser session aborted (client failed to send a heartbeat?)"));
             }.bind(this));
 
             try {

--- a/lib/runners/browser.js
+++ b/lib/runners/browser.js
@@ -5,6 +5,7 @@ var remoteRunner = require("./browser/remote-runner");
 var reporters = require("buster-test").reporters;
 var stackFilter = require("stack-filter");
 var _ = require("lodash");
+var when = require("when");
 
 // Error codes, as per FreeBSD's sysexit(3)
 // Errors are mapped to sysexit(3) error codes wherever that makes sense
@@ -102,7 +103,7 @@ function extractFile(error) {
     return match[1].replace(cwd, "");
 }
 
-function configError(callback, err) {
+function parseConfigError(err) {
     var error = err;
 
     if (/ENOENT/.test(err.message) && /'.*\*.*'/.test(err.message)) {
@@ -114,7 +115,8 @@ function configError(callback, err) {
                           "' is not a file or directory");
         error.code = EX_DATAERR;
     }
-    callback(error);
+
+    throw error;
 }
 
 function cacheability(cacheable, resourceSet) {
@@ -151,6 +153,7 @@ var testRun = {
     },
 
     endSession: function (session) {
+        if (!session) return;
         this.logger.info("Successfully closed session");
         session.endSession();
     },
@@ -225,7 +228,9 @@ var testRun = {
 
     startSession: function (client, callback) {
         return function (resourceSet) {
-            if (this.aborted) { return callback(); }
+            if (this.aborted) {
+                return callback();
+            }
 
             this.logger.info("Creating browser session");
 
@@ -258,23 +263,43 @@ var testRun = {
 
     start: function () {
         var client = createRampClient(this.options);
-        var self = this;
-        var done = function () { return self.done.apply(self, arguments); };
-        this.config.resolve().then(this.startSession(client, function (err, sessionInit) {
-            if (err) { return done(err); }
-            this.onInterrupt(function () { sessionInit.endSession(); });
 
-            sessionInit.onSessionAbort(function (e) {
-                this.abort(new Error(e.error || "Browser session aborted (client failed to send a heartbeat?)"));
-            }.bind(this));
+        this.config.resolve()
+            .catch(parseConfigError)
+            .then(function (resourceSet) {
+                // @todo: unmangle startSession() to be flatter
+                var d = when.defer();
 
-            try {
-                if (this.aborted) { return this.endSession(sessionInit); }
-                this.runTests(sessionInit, done);
-            } catch (e) {
-                done(e);
-            }
-        }.bind(this)), configError.bind(null, done));
+                var starterFn = this.startSession(client, function (err, sessionInit) {
+                    if (err) {
+                        d.reject(err);
+                    } else {
+                        d.resolve(sessionInit)
+                    }
+                });
+
+                starterFn(resourceSet);
+
+                return d.promise;
+            }.bind(this))
+            .then(function (sessionInit) {
+                if (this.aborted) {
+                    this.endSession(sessionInit);
+                    return; // @todo: unmagle and promisify runTests below
+                }
+
+                this.onInterrupt(function () {
+                    this.endSession(sessionInit);
+                });
+
+                sessionInit.onSessionAbort(function (e) {
+                    this.endSession(sessionInit);
+                    this.done(new Error(e.error || "Browser session aborted (client failed to send a heartbeat?)"));
+                }.bind(this));
+
+                this.runTests(sessionInit, this.done.bind(this));
+            }.bind(this))
+            .catch(this.done.bind(this));
     },
 
     onInterrupt: function (callback) {

--- a/lib/runners/node.js
+++ b/lib/runners/node.js
@@ -43,23 +43,10 @@ function processSection(config, section) {
     var d = when.defer();
     config.on("load:" + section, function (resourceSet) {
         readManifest(cacheFile(config), function (manifest) {
-            var pd = resourceSet.process(manifest);
-            when.chain(pd, d.resolver);
+            resourceSet.process(manifest).then(d.resolver.resolve, d.resolver.reject);
         });
     });
     return d.promise;
-}
-
-function manifestsGenerated(manifests) {
-    if (!this.processDeferred) { return; }
-    this.processDeferred.resolve(manifests);
-    delete this.processDeferred;
-}
-
-function manifestsFailed(err) {
-    if (!this.processDeferred) { return; }
-    this.processDeferred.reject(err);
-    delete this.processDeferred;
 }
 
 var testRun = {
@@ -85,14 +72,12 @@ var testRun = {
             var hookResolution = this.beforeRunHook();
             var configResolution = this.config.resolve();
 
-            var errorFunc = (function (err) {
-                this.done(err);
-            }.bind(this));
-            configResolution.otherwise(errorFunc);
-
-            when.all([hookResolution, configResolution]).
-                then(function (values) {
+            when.all([hookResolution, configResolution])
+                .then(function (values) {
                     this.runTests(values[1], values[0]);
+                }.bind(this))
+                .catch(function (e) {
+                    this.done(e);
                 }.bind(this));
         } catch (e) {
             this.done(e);
@@ -132,19 +117,14 @@ var testRun = {
 
     abort: function (err) {
         this.aborted = true;
-        delete this.processDeferred;
         this.done(err);
     },
 
     beforeRunHook: function () {
         this.config.runExtensionHook("beforeRun");
-        this.processDeferred = when.defer();
         var sections = ["libs", "sources", "testHelpers", "tests"];
-        when.all(sections.map(processSection.bind(null, this.config))).then(
-            manifestsGenerated.bind(this),
-            manifestsFailed.bind(this)
-        );
-        return this.processDeferred.promise;
+
+        return when.all(sections.map(processSection.bind(null, this.config)));
     }
 };
 

--- a/lib/test-cli.js
+++ b/lib/test-cli.js
@@ -19,10 +19,10 @@ function files(config) {
     return (config.resourceSet && config.resourceSet.load) || [];
 }
 
-function template(templateRoot, name, locals, callback) {
+function template(templateRoot, name, locals) {
     var templatePath = path.join(templateRoot, name + ".ejs");
     var content = fs.readFileSync(templatePath, "utf-8");
-    return ejs.render(content, { locals: locals });
+    return ejs.render(content, locals);
 }
 
 function helpTopics(templateRoot) {

--- a/lib/test-cli.js
+++ b/lib/test-cli.js
@@ -6,7 +6,6 @@ var bTest = require("buster-test");
 var stackFilter = require("stack-filter");
 var runAnalyzer = require("./run-analyzer");
 var TEMPLATE_ROOT = path.join(__dirname, "../views");
-var when = require("when");
 var _ = require("lodash");
 
 var colorOpt = {

--- a/package.json
+++ b/package.json
@@ -1,62 +1,68 @@
 {
-    "name": "buster-test-cli",
-    "version": "0.8.8",
-    "description": "Cli tools for Buster.JS test runners",
-    "homepage": "http://busterjs.org/docs/buster-test-cli",
-    "author": {
-        "name": "Christian Johansen",
-        "email": "christian@cjohansen.no",
-        "url": "http://cjohansen.no"
+  "name": "buster-test-cli",
+  "version": "0.8.8",
+  "description": "Cli tools for Buster.JS test runners",
+  "homepage": "http://busterjs.org/docs/buster-test-cli",
+  "author": {
+    "name": "Christian Johansen",
+    "email": "christian@cjohansen.no",
+    "url": "http://cjohansen.no"
+  },
+  "contributors": [
+    {
+      "name": "August Lilleaas",
+      "email": "august@augustl.com",
+      "url": "http://augustl.com"
     },
-    "contributors": [{
-        "name": "August Lilleaas",
-        "email": "august@augustl.com",
-        "url": "http://augustl.com"
-    }, {
-        "name": "Daniel Wittner",
-        "email": "d.wittner@gmx.de",
-        "url": "https://github.com/dwittner"
-    }, {
-        "name": "Matthias Kling",
-        "email": "m.kling@sprax.eu"
-    }, {
-        "name": "Sasha Depold",
-        "email": "sascha@depold.com",
-        "url": "http://depold.com"
-    }, {
-        "name": "Stein Magnus Jodal",
-        "email": "stein.magnus@jodal.no",
-        "url": "http://jodal.no"
-    }, {
-        "name": "Tobias Ebnöther",
-        "email": "ebi@gorn.ch"
-    }],
-    "main": "./lib/test-cli",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/busterjs/buster-test-cli.git"
+    {
+      "name": "Daniel Wittner",
+      "email": "d.wittner@gmx.de",
+      "url": "https://github.com/dwittner"
     },
-    "scripts": {
-        "test": "node run-tests.js",
-        "test-debug": "node --debug-brk run-tests.js"
+    {
+      "name": "Matthias Kling",
+      "email": "m.kling@sprax.eu"
     },
-    "dependencies": {
-        "buster-analyzer": "=0.5.0",
-        "ramp": "~1.0",
-        "ansi-grid": "=0.5.0",
-        "ansi-colorizer": "~1.0",
-        "buster-cli": "~0.6",
-        "buster-test": "~0.7",
-        "bane": "~1.0",
-        "stack-filter": "~1.0",
-        "ejs": "~0.4",
-        "when": "https://github.com/cujojs/when/tarball/1.8.1",
-        "lodash": "~1.0",
-        "platform": "~1.2"
+    {
+      "name": "Sasha Depold",
+      "email": "sascha@depold.com",
+      "url": "http://depold.com"
     },
-    "devDependencies": {
-        "buster-node": "*",
-        "referee": "~1.0",
-        "stream-logger": ">=0.3.0"
+    {
+      "name": "Stein Magnus Jodal",
+      "email": "stein.magnus@jodal.no",
+      "url": "http://jodal.no"
+    },
+    {
+      "name": "Tobias Ebnöther",
+      "email": "ebi@gorn.ch"
     }
+  ],
+  "main": "./lib/test-cli",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/busterjs/buster-test-cli.git"
+  },
+  "scripts": {
+    "test": "node run-tests.js",
+    "test-debug": "node --debug-brk run-tests.js"
+  },
+  "dependencies": {
+    "buster-analyzer": "0.6.x",
+    "ramp": "https://github.com/busterjs/ramp.git#update-deps",
+    "ansi-colorizer": "1.x",
+    "buster-cli": "0.7.x",
+    "buster-test": "https://github.com/busterjs/buster-test.git#update-deps",
+    "bane": "1.x",
+    "stack-filter": "1.x",
+    "ejs": "2.x",
+    "when": "1.x",
+    "lodash": "3.x",
+    "platform": "1.x"
+  },
+  "devDependencies": {
+    "buster-node": "0.7.x",
+    "stream-logger": "1.x"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -49,20 +49,20 @@
     "test-debug": "node --debug-brk run-tests.js"
   },
   "dependencies": {
-    "buster-analyzer": "0.6.x",
-    "ramp": "2.x",
     "ansi-colorizer": "1.x",
-    "buster-cli": "0.8.x",
-    "buster-test": "git://github.com/busterjs/buster-test.git#update-deps",
     "bane": "1.x",
-    "stack-filter": "1.x",
+    "buster-analyzer": "0.6.x",
+    "buster-cli": "0.8.x",
+    "buster-test": "0.8.x",
     "ejs": "2.x",
-    "when": "3.x",
     "lodash": "3.x",
-    "platform": "1.x"
+    "platform": "1.x",
+    "ramp": "2.x",
+    "stack-filter": "1.x",
+    "when": "3.x"
   },
   "devDependencies": {
-    "buster-node": "0.7.x",
+    "buster-node": "0.8.x",
     "stream-logger": "1.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ramp": "2.x",
     "ansi-colorizer": "1.x",
     "buster-cli": "0.8.x",
-    "buster-test": "https://github.com/busterjs/buster-test.git#update-deps",
+    "buster-test": "git://github.com/busterjs/buster-test.git#update-deps",
     "bane": "1.x",
     "stack-filter": "1.x",
     "ejs": "2.x",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "buster-analyzer": "0.6.x",
     "ramp": "2.x",
     "ansi-colorizer": "1.x",
-    "buster-cli": "0.7.x",
+    "buster-cli": "0.8.x",
     "buster-test": "https://github.com/busterjs/buster-test.git#update-deps",
     "bane": "1.x",
     "stack-filter": "1.x",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "buster-analyzer": "0.6.x",
-    "ramp": "https://github.com/busterjs/ramp.git#update-deps",
+    "ramp": "2.x",
     "ansi-colorizer": "1.x",
     "buster-cli": "0.7.x",
     "buster-test": "https://github.com/busterjs/buster-test.git#update-deps",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "bane": "1.x",
     "stack-filter": "1.x",
     "ejs": "2.x",
-    "when": "1.x",
+    "when": "3.x",
     "lodash": "3.x",
     "platform": "1.x"
   },

--- a/test/runners/browser-test.js
+++ b/test/runners/browser-test.js
@@ -617,23 +617,31 @@ buster.testCase("Browser runner", {
                 });
             },
 
-            "//builds cwd from session server and root": function () {
-                this.session.resourcesPath = "/aaa-bbb/resources";
+            "builds cwd from session server and root": function () {
+                this.session.getSession = this.stub().returns({
+                    resourcesPath: "/aaa-bbb/resources"
+                });
                 var run = this.createRun({ server: "localhost:1111" });
                 run.runTests(this.session);
 
                 assert.match(reporters.brief.create.args[0][0], {
-                    cwd: "http://localhost:1111/aaa-bbb/resources"
+                    stackFilter: {
+                        cwd: "http://localhost:1111/aaa-bbb/resources"
+                    }
                 });
             },
 
-            "//builds cwd from non-default session server and root": function () {
-                this.session.resourcesPath = "/aaa-bbb/resources";
+            "builds cwd from non-default session server and root": function () {
+                this.session.getSession = this.stub().returns({
+                    resourcesPath: "/aaa-bbb/resources"
+                });
                 var run = this.createRun({ server: "somewhere:2524" });
                 run.runTests(this.session);
 
                 assert.match(reporters.brief.create.args[0][0], {
-                    cwd: "http://somewhere:2524/aaa-bbb/resources"
+                    stackFilter: {
+                        cwd: "http://somewhere:2524/aaa-bbb/resources"
+                    }
                 });
             },
 

--- a/test/runners/node-test.js
+++ b/test/runners/node-test.js
@@ -172,11 +172,12 @@ buster.testCase("Node runner", {
             this.contextListeners = test.testContext.listeners;
             delete test.testContext.listeners;
             this.stub(fs, "writeFileSync");
-            cliHelper.cdFixtures();
+            this.cwd = cliHelper.cdFixtures();
         },
 
         tearDown: function () {
             test.testContext.listeners = this.contextListeners;
+            process.chdir(this.cwd);
         },
 
         "registers listener for created test cases": function (done) {

--- a/test/test-cli-test.js
+++ b/test/test-cli-test.js
@@ -35,11 +35,12 @@ buster.testCase("Test CLI", {
             runners: this.runners
         });
         this.exit = this.cli.cli.exit = this.spy();
-        cliHelper.cdFixtures();
+        this.cwd = cliHelper.cdFixtures();
     },
 
     tearDown: function (done) {
         cliHelper.clearFixtures(done);
+        process.chdir(this.cwd);
     },
 
     "help": {


### PR DESCRIPTION
Progress for https://github.com/busterjs/buster/issues/463
- [x] Wait for ramp (https://github.com/busterjs/ramp/pull/8)
- [x] Wait for buster-test (https://github.com/busterjs/buster-test/pull/32)
- [x] Upgrade when to v3
- [x] browser runner should abort run properly - do not allow `done` multiple times
- [x] should provide a default session-abort message

Review
- [x] `call done in case of no matching test files` does not nodeback
- [x] node tests using `.run()` don't always wait for async completion
